### PR TITLE
Update link to fontawesome icon's metadata.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 build/
 .gradle/
 .idea/

--- a/src/main/java/in/oneton/pencil/stencil/fontawesome/FontAwesomeDefinitionGenerator.java
+++ b/src/main/java/in/oneton/pencil/stencil/fontawesome/FontAwesomeDefinitionGenerator.java
@@ -36,7 +36,7 @@ import static java.util.stream.Collectors.joining;
 public class FontAwesomeDefinitionGenerator implements DefinitionGenerator {
 
   public static final String FONT_AWESOME_FREE_METADATA_ICONS_JSON_URL =
-      "https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/advanced-options/metadata/icons.json";
+      "https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/metadata/icons.json";
 
   private final String iconMetadataSourcePath;
   private final String stencilDestinationNameOrPath;


### PR DESCRIPTION
Fontawesome Free Icon's Metadata has move. 

This PR change the hardcoded link.

Add some macos gitignore has well.